### PR TITLE
Fix bug in dodge angle range render

### DIFF
--- a/SpeedFlipTrainer/SpeedFlipTrainer.cpp
+++ b/SpeedFlipTrainer/SpeedFlipTrainer.cpp
@@ -645,7 +645,7 @@ void SpeedFlipTrainer::RenderAngleMeter(CanvasWrapper canvas, float screenWidth,
 		{
 			ranges.push_back({ (char)50, (char)255, (char)50, 1, rTarget - greenRange, rTarget + greenRange });
 		}
-		else if (angleAdjusted < ryl)
+		else if (angleAdjusted < ryh)
 		{
 			ranges.push_back({ (char)255, (char)255, (char)50, 1, rTarget + greenRange, rTarget + yellowRange });
 		}


### PR DESCRIPTION
Fixes a render bug in the right side far yellow range for dodge angle.

Before:
<img width="529" alt="image" src="https://github.com/tynidev/SpeedFlipTrainer/assets/1103930/ac7ace5e-4b56-42eb-9526-c0d8ae9f547e">

After:
<img width="603" alt="image" src="https://github.com/tynidev/SpeedFlipTrainer/assets/1103930/167008c5-a93d-4ab5-9fa0-4673575a4f27">
